### PR TITLE
Increase allocation limit

### DIFF
--- a/config/settings.dhall
+++ b/config/settings.dhall
@@ -44,7 +44,7 @@ let emptyExternalSettings =
       } : ExternalSettings
 let emptyInternalSettings =
       { timeout = 10
-      , allocations = 10000000000
+      , allocations = 20000000000
       , inputSize = 1000000
       , sourceFilePrefix = ""
       , sourceFileExtension = ""


### PR DESCRIPTION
`x2` to current value. It seems not enough to handle something meaningful:

<img width="387" alt="Screenshot 2022-12-03 at 21 14 24" src="https://user-images.githubusercontent.com/6595049/205460132-21943ca6-dd34-46f8-a77f-cf59be59c0d6.png">
