### PR TITLE
Restore original font for `version` and `help`

### DIFF
--- a/src/Proof/Assistant/Response.hs
+++ b/src/Proof/Assistant/Response.hs
@@ -15,11 +15,13 @@ data InterpreterResponse = InterpreterResponse
   , interpreterResponseResponse :: !ByteString
   }
 
-toSendMessageRequest :: InterpreterResponse -> SendMessageRequest
-toSendMessageRequest InterpreterResponse{..} = SendMessageRequest
-  { sendMessageChatId                = SomeChatId interpreterResponseTelegramChatId
+toSendMessageRequest :: Bool -> InterpreterResponse -> SendMessageRequest
+toSendMessageRequest isMonospace InterpreterResponse{..} = SendMessageRequest
+  { sendMessageChatId                   = SomeChatId interpreterResponseTelegramChatId
   , sendMessageText
-      = "```\n" <> decodeUtf8 interpreterResponseResponse <> "\n```\n"
+      = if isMonospace
+        then "```\n" <> decodeUtf8 interpreterResponseResponse <> "\n```\n"
+        else decodeUtf8 interpreterResponseResponse
   , sendMessageParseMode                = Just MarkdownV2
   , sendMessageEntities                 = Nothing
   , sendMessageDisableWebPagePreview    = Nothing


### PR DESCRIPTION
After the last fix whole message text rendered as monospace. Version and Help messages should be excluded.