### PR TITLE
Fix markup for help version

### DIFF
--- a/src/Proof/Assistant/Bot.hs
+++ b/src/Proof/Assistant/Bot.hs
@@ -78,7 +78,8 @@ handleAction (Help req) model = model <# do
       Settings{..} = botSettings
   case HashMap.lookup (decodeUtf8 $ interpreterRequestMessage req) helpMessages of
     Nothing -> sendResponseBack False $ makeTelegramResponse req (encodeUtf8 help) 
-    Just helpMessage -> replyText helpMessage
+    Just helpMessage -> sendResponseBack False
+      $ makeTelegramResponse req (encodeUtf8 helpMessage)
 handleAction (Version req) model = model <# do
   let BotState {..} = model
       Settings{..} = botSettings

--- a/src/Proof/Assistant/Response.hs
+++ b/src/Proof/Assistant/Response.hs
@@ -21,8 +21,8 @@ toSendMessageRequest isMonospace InterpreterResponse{..} = SendMessageRequest
   , sendMessageText
       = if isMonospace
         then "```\n" <> decodeUtf8 interpreterResponseResponse <> "\n```\n"
-        else decodeUtf8 interpreterResponseResponse
-  , sendMessageParseMode                = Just MarkdownV2
+        else decodeUtf8 interpreterResponseResponse <> "\n"
+  , sendMessageParseMode                = if isMonospace then Just MarkdownV2 else Nothing
   , sendMessageEntities                 = Nothing
   , sendMessageDisableWebPagePreview    = Nothing
   , sendMessageDisableNotification      = Nothing


### PR DESCRIPTION
Render `/help`, `/version` response messages as Text