### PR TITLE
Update README and modify config to work with Lean 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,24 +124,30 @@ export IDRIS2_BIN_PATH="$HOME/.nix-profile/bin/idris2"
 2. Install `lean` via `nix`:
 
 ```bash
-nix-env -i lean
+nix-env -i lean4
 ```
 
-3. Install `leanproject` via `nix`:
+3. Create project directory:
 
-```bash
-nix-env -i mathlibtools
+```
+lake new leanproject
 ```
 
-4. Run `leanproject new lean`.
+It will create directory `leanproject` with all necessary files.
 
-5. Set `LEAN_BIN_PATH` environmental variable:
+4. Set `LEAN_BIN_PATH` environmental variable:
 
 ```bash
 export LEAN_BIN_PATH="$HOME/.nix-profile/bin/lean"
 ```
 
-6. Set `LEAN_PROJECT_PATH` to the newly created project directory.
+5. Set `LEAN_PROJECT_PATH` to the newly created project directory.
+
+6. Set `LAKE_BIN_PATH` environmental variable:
+
+```bash
+export LAKE_BIN_PATH="$HOME/.nix-profile/bin/lake"
+```
 
 ### Arend
 
@@ -150,7 +156,7 @@ export LEAN_BIN_PATH="$HOME/.nix-profile/bin/lean"
 2. Get `java` and `openjdk17` via `nix`:
 
 ```bash
-nix-env -i openjdk-17.0.4+8
+nix-env -iA nixpkgs.jdk17
 ```
 
 3. Set `JAVA_HOME` environment variable to your openjdk location. You can use `readlink $HOME/.nix-profile/bin/java` and strip `/bin/java` from the end.
@@ -181,7 +187,7 @@ You can read about CLI Wrapper here: https://github.com/AlloyTools/org.alloytool
 2. Get `java` and `openjdk17` via `nix`:
 
 ```bash
-nix-env -i openjdk-17.0.4+8
+nix-env -iA nixpkgs.jdk17
 ```
 
 3. Set `JAVA_HOME` environment variable to your openjdk location. You can use `readlink $HOME/.nix-profile/bin/java` and strip `/bin/java` from the end.
@@ -209,7 +215,7 @@ java -cp $NIX_PROFILE/share/alloy/alloy6.jar:$ALLOY_PROJECT_DIR/bin Main
 7. Set up `graphviz` and `imagemagick` for generating plots based on Alloy CLI Wrapper output:
 
 ```bash
-nix-env -i graphviz imagemagick
+nix-env -iA nixpkgs.graphviz nixpkgs.imagemagick
 ```
 
 8. Set `ALLOY_PATH` environment variable to `$NIX_PROFILE/share/alloy/alloy6.jar`.

--- a/config/settings.dhall
+++ b/config/settings.dhall
@@ -1,5 +1,6 @@
 let nixProfile = env:NIX_PROFILE as Text
 let leanBinPath = env:LEAN_BIN_PATH as Text
+let lakeBinPath = env:LAKE_BIN_PATH as Text
 let leanProjectPath = env:LEAN_PROJECT_PATH as Text
 
 let Limit = { soft : Natural, hard : Natural }
@@ -90,8 +91,8 @@ let idrisSettings = emptyExternalSettings //
       }
 let leanSettings =
       { externalLean = emptyExternalSettings //
-          { args = ["--profile"] : List Text
-          , executable = leanBinPath
+          { args = ["env", leanBinPath, "--profile", "--run"] : List Text
+          , executable = lakeBinPath
           , tempFilePrefix = "lean"
           , fileExtension = "lean"
           , time = 10
@@ -100,6 +101,7 @@ let leanSettings =
               , sandboxArgs =
                 [ "--unshare-all"
                 -- environmental variables
+                , "--setenv", "LAKE_BIN_PATH", lakeBinPath
                 , "--setenv", "LEAN_BIN_PATH", leanBinPath
                 , "--setenv", "LEAN_PROJECT_PATH", leanProjectPath
                 -- directories binds


### PR DESCRIPTION
Lean 4 does not use `mathplotlib` and `leanproject`. Instead, it comes with `lake` utility which is bundled together with `nixpkgs.lean4` package.