### PR TITLE
Support imports from `agda-stdlib`

### DIFF
--- a/config/settings.dhall
+++ b/config/settings.dhall
@@ -29,7 +29,11 @@ let InternalSettings =
       , sourceFilePrefix : Text
       , sourceFileExtension : Text
       }
-let AgdaSettings = { internal : InternalSettings }
+let AgdaSettings =
+      { internal : InternalSettings
+      , agdaStdlibDir : Text
+      , agdaSrcDir : Text
+      }
 let LeanSettings =
       { projectDir : Text
       , externalLean : ExternalSettings
@@ -120,12 +124,15 @@ let leanSettings =
           }
       , projectDir = leanProjectPath
       }
+let _agdaStdlibDir = env:AGDA_STDLIB_PATH as Text
 let agdaSettings =
       { internal = emptyInternalSettings //
           { sourceFilePrefix = "agda"
           , sourceFileExtension = "agda"
           , timeout = 60
           }
+      , agdaStdlibDir = "${_agdaStdlibDir}"
+      , agdaSrcDir = "src"
       }
 let rzkSettings = emptyInternalSettings // { timeout = 60 }
 let _arendLibDir = env:AREND_STDLIB_PATH as Text

--- a/src/Agda/Interaction/Command.hs
+++ b/src/Agda/Interaction/Command.hs
@@ -95,5 +95,6 @@ storeRequestContent absFilepath content = do
         [ BS8.unwords [ "module", moduleName, "where" ]
         , ""
         , content
+        , ""
         ]
   BS8.writeFile (filePath absFilepath) moduleContent

--- a/src/Proof/Assistant/Settings.hs
+++ b/src/Proof/Assistant/Settings.hs
@@ -42,7 +42,9 @@ data InternalInterpreterSettings = InternalInterpreterSettings
   } deriving (Generic, FromDhall)
 
 data AgdaSettings = AgdaSettings
-  { internal :: !InternalInterpreterSettings 
+  { internal :: !InternalInterpreterSettings
+  , agdaSrcDir :: !FilePath
+  , agdaStdlibDir :: !FilePath
   } deriving (Generic, FromDhall)
 
 data LeanSettings = LeanSettings


### PR DESCRIPTION
Configure bot 
- to save chat data inside `agda-stdlib` project 
- and to load modules from `agda-stdlib` when required.